### PR TITLE
Injects policy env vars into WASI environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-/target
+target
 /bin
 .DS_Store
 /result

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 - Fixed inconsistent spelling of "wasette" to "wassette" in configuration paths and documentation comments ([#TBD](https://github.com/microsoft/wassette/pull/TBD))
 - Fixed broken links in README.md pointing to documentation files in wrong directory paths ([#TBD](https://github.com/microsoft/wassette/pull/TBD))
 - Add cargo audit configuration to acknowledge unmaintained `paste` dependency warning ([#169](https://github.com/microsoft/wassette/pull/169))
+- Environment variables allowed by policy were only stored as config variables and not visible to std::env::var inside components; they are now injected into the WASI environment at instantiation ([#TBD](https://github.com/microsoft/wassette/pull/TBD))
 
 ### Added
 

--- a/crates/wassette/src/wasistate.rs
+++ b/crates/wassette/src/wasistate.rs
@@ -102,6 +102,12 @@ impl WasiStateTemplate {
             )?;
         }
 
+        // Inject forwarded config variables as real WASI environment variables so that
+        // component code using std::env::var can observe them.
+        for (k, v) in &self.config_vars {
+            ctx_builder.env(k, v);
+        }
+
         Ok(WasiState {
             ctx: ctx_builder.build(),
             table: wasmtime_wasi::ResourceTable::default(),


### PR DESCRIPTION
Forwards allowed environment variables into the WASI runtime so component code using standard env lookups can observe them, fixing prior invisibility when only tracked as config vars.